### PR TITLE
Disable chat moving during Comp animations

### DIFF
--- a/_tf2hud/scripts/hudanimations_tf.txt
+++ b/_tf2hud/scripts/hudanimations_tf.txt
@@ -1418,12 +1418,12 @@ event QuestItem_Highlight_Off_Halloween
 //--------------------------------------------------------------------------
 event CompetitiveGame_LowerChatWindow
 {
-	Animate HudChat ypos r140 Accel 0 0
+	// Animate HudChat ypos r140 Accel 0 0
 }
 
 event CompetitiveGame_RestoreChatWindow
 {
-	Animate HudChat ypos 275 Accel 0 0
+	// Animate HudChat ypos 275 Accel 0 0
 }
 
 event HudTournament_MoveChatWindow


### PR DESCRIPTION
Fixes Chat ending up on a different position than the one in res files, therefore fixing it inadvertently showing up in Stream HUD.