### PR TITLE
Fix ammo icon clipping with ammo number

### DIFF
--- a/_budhud/resource/ui/targetid.res
+++ b/_budhud/resource/ui/targetid.res
@@ -159,7 +159,7 @@
 	
 	"AmmoIcon"
 	{
-		"xpos"														"48"
+		"xpos"														"45"
 		"ypos"														"50"
 	}
 	

--- a/resource/ui/spectatorguihealth.res
+++ b/resource/ui/spectatorguihealth.res
@@ -1,5 +1,5 @@
+	#base	"..\..\#customization\_enabled\bh_spectatorguihealth_cross.res"	
 	#base	"..\..\#customization\_enabled\bh_spectatorguihealth_size.res"
-	#base	"..\..\#customization\_enabled\bh_spectatorguihealth_cross.res"
 	#base	"..\..\_stream\resource\ui\spectatorguihealth.res"
 	#base	"..\..\_budhud\resource\ui\spectatorguihealth.res"
 	#base	"..\..\_tf2hud\resource\ui\spectatorguihealth.res"


### PR DESCRIPTION
Fixes this: https://cdn.discordapp.com/attachments/257945014124937217/701354192727703612/20200419104803_1.jpg

Same issue fixed in rayshud: https://github.com/raysfire/rayshud/issues/144