### PR TITLE
Show bh_skins in the console autocomplete

### DIFF
--- a/cfg/bh_aliases.cfg
+++ b/cfg/bh_aliases.cfg
@@ -4,7 +4,8 @@
 	////////////////////////////////////////////////////////////////////////////////////////////////////
 	clear
 	
-	alias		bh_skins		"incrementvar mat_picmip -1 2 1"
+	alias           bh_skins                "incrementvar mat_picmip -1 2 1"
+	setinfo         bh_skins                "Cycles mat_picmip to improve or reduce skin quality in backpack and in-game" // shows in autocomplete
 	
 	echo ==========================================================================================================
 	echo	Useful Aliases set


### PR DESCRIPTION
You can use `setinfo` to make your own convars which show up in autocomplete. Since you still have an alias though, you can't modify/use this convar anyway.