### PR TITLE
Fix some problems introduced in #407

### DIFF
--- a/HUD Updater and Error Checker.ps1
+++ b/HUD Updater and Error Checker.ps1
@@ -62,7 +62,7 @@ function Extract_VPK_Files
         $len_left = $max_cmd_len - $vpk.Length - $VpkPath.Length - 3  # this 3 includes the x and spaces
         while (($i -lt $FileNames.Count) -and ($FileNames[$i].Length -le $len_left)) {
             $batch.Add($FileNames[$i]) | Out-Null
-            $len_left -= $FileNames[0].Length
+            $len_left -= $FileNames[$i].Length
             $len_left -= 3  # each filename requires a space and may need quotation marks
             $i += 1
         }
@@ -90,7 +90,7 @@ function Extract_VPK_Directory
 #################
 function Options_Initial
 {
-    #Clear-Host
+    Clear-Host
     Write-Host -foregroundcolor "White" -backgroundcolor "Blue" "================================"
     Write-Host -foregroundcolor "White" -backgroundcolor "Blue" "budhud Updater and Error Checker"
     Write-Host -foregroundcolor "White" -backgroundcolor "Blue" "================================"
@@ -432,7 +432,7 @@ function Pass_ExtractDefaultHUD
         ForEach-Object {$_ -ireplace '\$OSX|\$X360|_minmode|_lodef|_hidef|if_', '_disabled_'} |
         Set-Content $file.FullName
     }
-    Write-Host -foregroundcolor "White" -backgroundcolor "Blue" "Removed OSX, X360, _minmode, _lodef, _hidef, and _if lines."
+    Write-Host -foregroundcolor "White" -backgroundcolor "Blue" "Removed OSX, X360, _minmode, _lodef, _hidef, and if_ lines."
 
 
     Write-Host -foregroundcolor "White" -NoNewLine "Copying over stubborn files..."

--- a/HUD Updater and Error Checker.ps1
+++ b/HUD Updater and Error Checker.ps1
@@ -64,7 +64,7 @@ function Extract_VPK_Files
     # this loop will run infinitely if a single filename would go over the limit. let's hope that doesn't happen.
     $i = 0
     $batch = [System.Collections.ArrayList]::new()
-    Write-Progress -Activity $activity -Status "Extracting" -PercentComplete 0 
+    Write-Progress -Activity $activity -Status "Extracting" -PercentComplete 0
     while ($i -lt $FileNames.Count) {
         $batch.Clear()
         $len_left = $max_cmd_len - $vpk.Length - $VpkPath.Length - 3  # this 3 includes the x and spaces


### PR DESCRIPTION
Oops, looks like I made a few mistakes in my last PR. This one fixes them.

- fix command line length calculation
  at first, the script assumed each filename was the same length as the
  first. this worked purely by happenstance.
- uncomment Clear-Host
  I commented this out so I could see error messages, then forgot to
  uncomment it before committing.
- \_if -> if_
  updated status line to properly reflect the changes the script is
  actually making.

This PR also adds some progress bars while extracting the default HUD files, because why not.