### PR TITLE
update the powershell script to check for new tf2 `x64_test` executable

### DIFF
--- a/budhud Updater.ps1
+++ b/budhud Updater.ps1
@@ -123,9 +123,9 @@ function Check_TF2Running {
 
     If
     (
-        Get-Process hl2 -ErrorAction SilentlyContinue
+        Get-Process hl2, tf_win64 -ErrorAction SilentlyContinue
     ) {
-        Write-Host -foregroundcolor "White" -backgroundcolor "Red" "hl2.exe detected"
+        Write-Host -foregroundcolor "White" -backgroundcolor "Red" "hl2 / tf_win64.exe detected"
         Write-Host ""
 
         Write-Host -foregroundcolor "White" -backgroundcolor "Red" "Outcome"
@@ -167,7 +167,7 @@ function Check_UpdateFiles_DefaultHUD {
 
         Write-Host -foregroundcolor "White" -backgroundcolor "Green" "Solution"
         Write-Host -foregroundcolor "White" "Verify that the hud is installed correctly."
-        Write-Host -foregroundcolor "White" "Expected location: ../Team Fortress 2/custom/budhud/HUD Updater and Error Checker.ps1"
+        Write-Host -foregroundcolor "White" "Expected location: ../Team Fortress 2/custom/budhud/budhud Updater.ps1"
         Write-Host ""
         Break
     }
@@ -207,12 +207,14 @@ function Check_InvokeWebRequest {
 ################
 function Check_HUDFiles {
     # Check for hl2.exe file
-    Write-Host -foregroundcolor "White" -NoNewLine "Checking for hl2.exe... "
+    Write-Host -foregroundcolor "White" -NoNewLine "Checking for hl2 / tf_win64.exe... "
     $hl2 = Maybe_Path $tf "../hl2.exe"
+    $tf64 = Maybe_Path $tf "../tf_win64.exe"
 
     If
     (
-        ![String]::IsNullOrEmpty($hl2)
+        ![String]::IsNullOrEmpty($hl2),
+        ![String]::IsNullOrEmpty($tf64)
     ) {
         Write-Host -foregroundcolor "White" -backgroundcolor "Blue" "File found"
     }

--- a/budhud Updater.ps1
+++ b/budhud Updater.ps1
@@ -207,20 +207,20 @@ function Check_InvokeWebRequest {
 ################
 function Check_HUDFiles {
     # Check for hl2.exe file
-    Write-Host -foregroundcolor "White" -NoNewLine "Checking for hl2 / tf_win64.exe... "
+    Write-Host -foregroundcolor "White" -NoNewLine "Checking for hl2 or tf_win64.exe... "
     $hl2 = Maybe_Path $tf "../hl2.exe"
     $tf64 = Maybe_Path $tf "../tf_win64.exe"
 
     If
     (
-        ![String]::IsNullOrEmpty($hl2),
+        ![String]::IsNullOrEmpty($hl2) -or
         ![String]::IsNullOrEmpty($tf64)
     ) {
         Write-Host -foregroundcolor "White" -backgroundcolor "Blue" "File found"
     }
 
     Else {
-        Write-Host -foregroundcolor "White" -backgroundcolor "Red" "Could not locate hl2.exe"
+        Write-Host -foregroundcolor "White" -backgroundcolor "Red" "Could not locate hl2 or tf_win64.exe"
         Write-Host ""
 
         Write-Host -foregroundcolor "White" -backgroundcolor "Red" "Outcome"


### PR DESCRIPTION
This PR updates the `Get-Process` and `Check_HUDFiles` functions to detect the new executable name currently found in the `x64_test` tf2 beta branch (`tf_win64.exe`)

i also updated one of the lines in `Check_UpdateFiles_DefaultHUD` to point to the correct filename of the shell script

this was also my first time writing any kind of powershell code and PRing to this repo, so please let me know if something is wrong

note: there's also a `tf.exe` executable that is in the same root folder as the others, but didn't include it due to not being able to test it.

most of this is also for some futureproofing in the case that the 64-bit update ever comes out...