### PR TITLE
Fixed item popup in Mann Co. Catalog

### DIFF
--- a/_budhud/resource/ui/charinfoarmorysubpanel.res
+++ b/_budhud/resource/ui/charinfoarmorysubpanel.res
@@ -70,6 +70,13 @@
 
     "mouseoveritempanel"
     {
+        "wide"                                                      "200"
+        "tall"                                                      "150"
+
+        "text_ypos"                                                 "15"
+        "text_center_x"                                             "1"
+        "model_center_x"                                            "1"
+
         "itemmodelpanel"
         {
             "allow_rot"                                             "0"


### PR DESCRIPTION
Was a bit misaligned, also made it a bit smaller, similar to how it is in the default HUD.

Before:
![20240627175746_1](https://github.com/rbjaxter/budhud/assets/50501742/9f360ade-e879-43e0-a5c2-4a630e050a6e)

After:
![20240627180040_1](https://github.com/rbjaxter/budhud/assets/50501742/88d59089-256a-4138-b575-f7705ee4c7ed)
