### PR TITLE
Improvements to `menu_thumb_missing` fix

### DIFF
--- a/_budhud/resource/ui/mainmenuoverride_preloading.res
+++ b/_budhud/resource/ui/mainmenuoverride_preloading.res
@@ -81,4 +81,7 @@
     "icon_obj_5_blu_locked" { "ControlName" "ImagePanel" "ypos" "r-6969" "visible" "0" "enabled" "0" "image" "../sprites/obj_icons/icon_obj_5_blu_locked" }
     "icon_obj_5_red" { "ControlName" "ImagePanel" "ypos" "r-6969" "visible" "0" "enabled" "0" "image" "../sprites/obj_icons/icon_obj_5_red" }
     "icon_obj_5_red_locked" { "ControlName" "ImagePanel" "ypos" "r-6969" "visible" "0" "enabled" "0" "image" "../sprites/obj_icons/icon_obj_5_red_locked" }
+
+    // menu_thumb_missing
+    "menu_thumb_missing" { "ControlName" "ImagePanel" "ypos" "r-6969" "visible" "0" "enabled" "0" "image" "../vgui/maps/menu_thumb_missing" }
 }

--- a/materials/vgui/maps/menu_thumb_Missing.vmt
+++ b/materials/vgui/maps/menu_thumb_Missing.vmt
@@ -1,7 +1,0 @@
-"UnlitGeneric"
-{
-    "$baseTexture"                                                  "vgui/replay/thumbnails/menu_thumb_Missing"
-    "$translucent"                                                  "1"
-    "$vertexcolor"                                                  "1"
-    "$vertexalpha"                                                  "1"
-}

--- a/materials/vgui/maps/menu_thumb_missing.vmt
+++ b/materials/vgui/maps/menu_thumb_missing.vmt
@@ -1,0 +1,1 @@
+"UnlitGeneric" {}


### PR DESCRIPTION
Console errors about the missing VGUI material `menu_thumb_missing` still occur when connecting to a casual server for the first time. Adding `menu_thumb_missing` to preloading fixes this. In addition, the `menu_thumb_missing.vmt` file itself can be made mostly empty, and its name can be lowercased (thanks @Hypnootize for [lighthud](https://github.com/Hypnootize/lighthud)).

The relative file path (`"../vgui/**"`) is required.