### PR TITLE
Refixed bh_player_healthcross_inset.res (Alternative Pin Version)

### DIFF
--- a/#customization/bh_player_healthcross_inset.res
+++ b/#customization/bh_player_healthcross_inset.res
@@ -12,16 +12,18 @@
 
     "PlayerStatusHealthBonusImage"
     {
-        "xpos"                                                      "95"
-        "ypos"                                                      "46"
-        "wide"                                                      "60"
-        "tall"                                                      "60"
+        "xpos"                                                      "93"
+        "ypos"                                                      "44"
+        "wide"                                                      "64"
+        "tall"                                                      "64"
     }
 
     "PlayerStatusHealthImage"
     {
-        "xpos"                                                      "95"
-        "ypos"                                                      "46"
+        "pin_to_sibling"                                            "PlayerStatusHealthImageBG"
+
+        "xpos"                                                      "-2"
+        "ypos"                                                      "-2"
         "wide"                                                      "60"
         "tall"                                                      "60"
         "visible"                                                   "1"
@@ -30,10 +32,8 @@
 
     "PlayerStatusHealthImageBG"
     {
-        "pin_to_sibling"                                            "PlayerStatusHealthImage"
-
-        "xpos"                                                      "2"
-        "ypos"                                                      "2"
+        "xpos"                                                      "93"
+        "ypos"                                                      "44"
         "wide"                                                      "64"
         "tall"                                                      "64"
         "visible"                                                   "1"

--- a/#customization/bh_player_healthcross_inset.res
+++ b/#customization/bh_player_healthcross_inset.res
@@ -2,7 +2,7 @@
 {
     "bh_PlayerStatusPin"
     {
-        "xpos"                                                      "c-210"
+        "xpos"                                                      "c-211"
         "ypos"                                                      "10"
     }
 
@@ -12,10 +12,10 @@
 
     "PlayerStatusHealthBonusImage"
     {
-        "xpos"                                                      "92"
-        "ypos"                                                      "43"
-        "wide"                                                      "66"
-        "tall"                                                      "66"
+        "xpos"                                                      "95"
+        "ypos"                                                      "46"
+        "wide"                                                      "60"
+        "tall"                                                      "60"
     }
 
     "PlayerStatusHealthImage"
@@ -32,10 +32,10 @@
     {
         "pin_to_sibling"                                            "PlayerStatusHealthImage"
 
-        "xpos"                                                      "3"
-        "ypos"                                                      "3"
-        "wide"                                                      "65"
-        "tall"                                                      "65"
+        "xpos"                                                      "2"
+        "ypos"                                                      "2"
+        "wide"                                                      "64"
+        "tall"                                                      "64"
         "visible"                                                   "1"
         "enabled"                                                   "1"
     }


### PR DESCRIPTION
This is the alternative version with the pin.

Original Description:

I reverted `bh_player_heatlhcross_inset.res` to its original values and gave it the proper fix this time. This new fix should make it so `PlayerStatusHealthImageBG` and `PlayerStatusHealthBonusImage` are perfectly aligned no matter what aspect ratio or resolution is set. `PlayerStatusHealthImage` will still misalign slightly inside `PlayerStatusHealthImageBG` on depending on the resolution, but it's at least as good as the default HUD now. This fix was attempted after I studied the default HUD for a bit.

Pictures are taken with a 1600x900 resolution:

Current (Figure 1):
![20240727224828_1](https://github.com/user-attachments/assets/f4769801-e6ef-43e7-9ebc-7d5ae6c8ba11)

New (Figure 2):
![20240727224850_1](https://github.com/user-attachments/assets/cf58e740-b036-4618-9a81-a1a595a139fa)

Old (Figure 3):
![20240727225002_1](https://github.com/user-attachments/assets/00bb5209-d29d-4193-879a-8a2489cc2793)

New w/ Pin (Figure 4) (looks like old version):
![20240727225527_1](https://github.com/user-attachments/assets/12a1d6c4-e2d3-4d84-b105-004f98e282cd)

Default (Figure 5) (looks like new version):
![Overheal Lowest](https://github.com/user-attachments/assets/6271683e-0b2a-449d-93b0-0bfb532333c4)

Originally, I thought the problem was that the values in `PlayerStatusHealthBonusImage` and `PlayerStatusHealthImageBG` needed to be tweaked to better fit `PlayerStatusHealthImage`, but after giving more of a look into it, it seems like the real problem was that pinning `PlayerStatusHealthImageBG` to `PlayerStatusHealthImage` gave them bad alignment between each other. I removed the pin from `PlayerStatusHealthImageBG` and gave it the positioning difference from `PlayerStatusHealthImage` identical to the default HUD, which is what the old `PlayerStatusHealthImageBG` attempted to do while pinned.
/

If you want to keep `PlayerStatusHealthImage` and `PlayerStatusHealthImageBG` pinned together, you'll actually have to switch it around and pin `PlayerStatusHealthImage` to `PlayerStatusHealthImageBG,` then adjust its values accordingly. The result is that `PlayerStatusHealthImageBG` and `PlayerStatusHealthBonusImage` will be properly aligned with each other, but `PlayerStatusHealthImage` has problems with its alignment inside `PlayerStatusHealthBG` on 1600x900 resolutions (see Figure 4).

Compared to it without the pin, this version aligns better in 5 out of 12 resolutions I tested (720x576, 1024x768, 1360x768, 1366x768, 1280x768), although there are resolutions where both are noticeably misaligned in different, yet equal ways (1152x864) or identically aligned/misaligned to the naked eye (5 resolutions: 640x480, 800x600, 1280x720, 720x480, 1280x800). That means that it's only worse than without the pin in one tested resolution (1600x900). This may change with higher resolutions, but I can't test that. Having a 1600x900 monitor, I'm a bit biased towards the version with no pin. However, if you want a commit with the pin, I've opened an alternative pull request that has it. If you like this change, you only have to accept one of them.

(I'm not adding the resolution comparisons because this is running pretty long and I don't want to bloat this description too much)

I also reverted `bh_PlayerStatusPin` to have its original xpos value because I didn't realize how difficult status effects could be under lower resolutions (status effects shifting to the left and wider spacing between each other as resolution lowers). Because every `HudPlayerHealth.res` in budhud is slightly more left than it should be on my monitor (1600x900), I think the problem is that the resolution I use is a bit lower than what BudHud is made for. That is, assuming the status effect alignment problem stops at a certain high enough resolution.

On a side note, I noticed how `bh_player_m0re_healthcross_inset.res` is nearly identical to `bh_player_healthcross_inset.res.` If you'd like, I can make similar change in that file, albeit it won't be the same as the original in m0rehud unless I forward the same changes there.