### PR TITLE
Refixed bh_player_healthcross_inset.res again :(

### DIFF
--- a/#customization/bh_player_healthcross_inset.res
+++ b/#customization/bh_player_healthcross_inset.res
@@ -20,10 +20,8 @@
 
     "PlayerStatusHealthImage"
     {
-        "pin_to_sibling"                                            "PlayerStatusHealthImageBG"
-
-        "xpos"                                                      "-2"
-        "ypos"                                                      "-2"
+        "xpos"                                                      "95"
+        "ypos"                                                      "46"
         "wide"                                                      "60"
         "tall"                                                      "60"
         "visible"                                                   "1"


### PR DESCRIPTION
Pinning `PlayerStatusHealthImage` to `PlayerStatusHealthImageBG` in #515 somehow broke the alignment of status effects to the health cross. I'm fixing it by changing it to the no-pin fix from #514.

1600x900 with 6 status effects (addcond 58; addcond 59; addcond 60; addcond 48; addcond 30; addcond 93)

Current:
![20240729004227_1](https://github.com/user-attachments/assets/9475933d-ee73-47b5-a174-26ed34e76da3)

Fixed:
![20240729004306_1](https://github.com/user-attachments/assets/ebf8b2df-cd16-4d1e-ac22-490fca82a207)

Super Old (Before me):
![20240729004256_1](https://github.com/user-attachments/assets/291c7a84-e32d-4df1-adb3-0c8a0f955fe4)

I didn't know that pinning `PlayerStatusHealthImage` to `PlayerStatusHealthImageBG` would affect `bh_PlayerStatusPin` since its positioning is independent to them. None of the files I thought were relevant suggested that something like this could happen either. You might want to add a note inside the file stating that pinning `PlayerStatusHealthImage` to `PlayerStatusHealthImageBG` breaks `bh_PlayerStatusPin` for future reference.

If you really want to keep the pin, you'll have to adjust the `bh_PlayerStatusPin` `xpos` inside `bh_player_healthcross_inset.res`. I haven't tried that because from my experience, there's a chance that fixing it this way won't produce the exact same positioning as before.