### PR TITLE
Slightly improved health cross element alignment

### DIFF
--- a/#customization/bh_player_healthcross.res
+++ b/#customization/bh_player_healthcross.res
@@ -19,8 +19,10 @@
 
     "PlayerStatusHealthImage"
     {
-        "xpos"                                                      "42"
-        "ypos"                                                      "62"
+        "pin_to_sibling"                                            "PlayerStatusHealthImageBG"
+
+        "xpos"                                                      "-2"
+        "ypos"                                                      "-2"
         "wide"                                                      "30"
         "tall"                                                      "30"
         "visible"                                                   "1"
@@ -29,10 +31,8 @@
 
     "PlayerStatusHealthImageBG"
     {
-        "pin_to_sibling"                                            "PlayerStatusHealthImage"
-
-        "xpos"                                                      "2"
-        "ypos"                                                      "2"
+        "xpos"                                                      "40"
+        "ypos"                                                      "60"
         "wide"                                                      "34"
         "tall"                                                      "34"
         "visible"                                                   "1"

--- a/#customization/bh_player_healthcross.res
+++ b/#customization/bh_player_healthcross.res
@@ -19,10 +19,8 @@
 
     "PlayerStatusHealthImage"
     {
-        "pin_to_sibling"                                            "PlayerStatusHealthImageBG"
-
-        "xpos"                                                      "-2"
-        "ypos"                                                      "-2"
+        "xpos"                                                      "42"
+        "ypos"                                                      "62"
         "wide"                                                      "30"
         "tall"                                                      "30"
         "visible"                                                   "1"


### PR DESCRIPTION
This fix is similar to #514. Specifically, that includes this file having a similar m0rehud version.

This new fix makes it so `PlayerStatusHealthImageBG` and `PlayerStatusHealthBonusImage` are perfectly aligned no matter what aspect ratio. This also sometimes fixes the alignment between `PlayerStatusHealthImage` and `PlayerStatusHealthImageBG` across different aspect ratios.

All pictures were taken in a 1600x900 resolution and with addcond 58 for 1 status effect

Current:
![20240729010901_1](https://github.com/user-attachments/assets/0d32832c-6f1a-4cdf-98ab-dde6b7404032)

Fixed:
![20240729010731_1](https://github.com/user-attachments/assets/f0f72a59-09bf-4b22-86a5-6367daf34e5b)

Hidden Pin Fixed (Status Effect Positioning Breaks):
![20240729010935_1](https://github.com/user-attachments/assets/ccbee3c5-82db-4c87-a077-c89f6ffae0f9)

It's a pretty small fix considering this new version will only be noticeable on 3 different resolutions. For 1024x720, only `PlayerStatusHealthImage` and `PlayerStatusHealthImageBG` were slightly misaligned beforehand. For 1600x900 and 1280x800, only `PlayerStatusHealthImageBG` and `PlayerStatusHealthBonusImage` were fixed, though `PlayerStatusHealthImage` and `PlayerStatusHealthImageBG` are barely still misaligned. The 800x600 and 1152x864 resolutions are still going to have `PlayerStatusHealthImage` and `PlayerStatusHealthImageBG` misaligned.

While testing all the resolutions I could, I noticed that the new health cross doesn't show the bonus image when the player has 1 overheal on 5 different resolutions (1024x768, 1280x720, 1360x768, 1366x768, 1280x768). After checking, this is just the exact current behavior.

This fix is similar to the one like in #514. However, I've added a fix with the pin before the final no-pin fix in case you want to test it for higher resolutions. Unlike in #514, the pin fix is only better than the no-pin fix on 1 resolution (1280x800) while the other 11 resolutions I tested have them identical to each other.

Update: This description was originally worded to push the fix with the pin (like #514). However, I recently learned that pinning `PlayerStatusHealthImage` to `PlayerStatusHealthImageBG` breaks the status effect alignment, which is why it's the way that it is now (read #519). Like I said there, you might want to add a note inside the file stating that pinning `PlayerStatusHealthImage` to `PlayerStatusHealthImageBG` breaks `bh_PlayerStatusPin` for future reference.