### PR TITLE
Fix globalchat.res from breaking

### DIFF
--- a/_budhud/resource/ui/globalchat.res
+++ b/_budhud/resource/ui/globalchat.res
@@ -7,4 +7,9 @@
         "chat_color_chat_text"                                      "bh_white"
         "chat_color_party_event"                                    "bh_yellow"
     }
+
+    "chatlog"
+    {
+        "pinCorner"
+    }
 }


### PR DESCRIPTION
Added `chatlog` element with empty `pinCorner` value. This fixes the menu party chat from breaking. You can even add the `CompetitiveGame_LowerChatWindow`, `CompetitiveGame_RestoreChatWindow`, and `HudTournament_MoveChatWindow` events in [hudanimations_budhud.txt](https://github.com/rbjaxter/budhud/blob/master/_budhud/scripts/hudanimations_budhud.txt) back and it'll work. It was just that one value for some reason. Alternatively, you can delete `pinCorner` in the [_tf2hud globalchat.res](https://github.com/rbjaxter/budhud/blob/master/_tf2hud/resource/ui/globalchat.res) `chatlog`. Credits to @Hypnootize for having the fix hidden in [m0rehud](https://github.com/Hypnootize/m0rehud).

https://github.com/user-attachments/assets/8f697d12-1b07-40c3-9dd3-a5f914bc135b

(The long pause in the middle was because I pressed my `hud_reloadscheme` bind, then realized I didn't add the fix, so I had to do that and `hud_reloadscheme` again)

One thing to note is that when I tried to show the fix the starting game menu, the original plan, it didn't work at first. It's fine though, as starting the game with the fix preloaded or loading the fix in-game and then exiting to the menu works. I tested it, and it might have had something to do with using `hud_reloadscheme` through console instead of a bind. I know that doesn't really make sense, but that was the difference.

https://github.com/user-attachments/assets/73365792-a611-4201-9d63-2b8fe2934de3

Hopefully nothing breaks.