### PR TITLE
Fix globalchat.res from breaking on 1600x900

### DIFF
--- a/_budhud/resource/ui/globalchat.res
+++ b/_budhud/resource/ui/globalchat.res
@@ -7,4 +7,9 @@
         "chat_color_chat_text"                                      "bh_white"
         "chat_color_party_event"                                    "bh_yellow"
     }
+
+    "chatlog"
+    {
+        "pinCorner"                                                 "0"
+    }
 }


### PR DESCRIPTION
New requested version of #523, see there for full details.

Added `chatlog` element with `pinCorner` set to `0`. This fixes the menu party chat from breaking. Thanks to @qkeitoe for revising the fix.