### PR TITLE
Add `"default" "1"` to `bh_Continue` buttons

### DIFF
--- a/_budhud/resource/ui/mapinfomenu.res
+++ b/_budhud/resource/ui/mapinfomenu.res
@@ -19,7 +19,8 @@
     {
         "ypos"                                                      "r-6969"
         "visible"                                                   "0"
-        "enabled"                                                   "0"
+        "enabled"                                                   "1" // Must be set to 1, otherwise “default” “0” will not take effect
+        "default"                                                   "0"
     }
 
     "MapInfoBack"
@@ -33,7 +34,8 @@
     {
         "ypos"                                                      "r-6969"
         "visible"                                                   "0"
-        "enabled"                                                   "0"
+        "enabled"                                                   "1" // Must be set to 1, otherwise “default” “0” will not take effect
+        "default"                                                   "0"
     }
 
     "MapImage"
@@ -90,6 +92,7 @@
         "labelText"                                                 "#bh_Continue_QK"
         "font"                                                      "bh_Font12"
         "textAlignment"                                             "center"
+        "default"                                                   "1"
         "Command"                                                   "continue"
 
         "defaultBgColor_override"                                   "bh_Theme_BG20"

--- a/_budhud/resource/ui/textwindow.res
+++ b/_budhud/resource/ui/textwindow.res
@@ -48,7 +48,8 @@
     {
         "ypos"                                                      "r-6969"
         "visible"                                                   "0"
-        "enabled"                                                   "0"
+        "enabled"                                                   "1" // Must be set to 1, otherwise “default” “0” will not take effect
+        "default"                                                   "0"
     }
 
     "bh_Continue"
@@ -68,6 +69,7 @@
         "labelText"                                                 "#bh_Continue_QK"
         "font"                                                      "bh_Font12"
         "textAlignment"                                             "center"
+        "default"                                                   "1"
         "Command"                                                   "okay"
 
         "defaultBgColor_override"                                   "bh_Theme_BG20"


### PR DESCRIPTION
This feature makes it possible to skip the intro screens when logging into a server by pressing either Space or Enter.

I assume these are the panels that #506 was referring to. But even if not, I think the suggested feature is useful.

Also, there is the `bh_Skip` panel in the `IntroMenu`, but I don't think it's worth adding `"default" "1"` to it (but I can if you'd like).