### PR TITLE
Add default `valve.rc` commands

### DIFF
--- a/cfg/valve.rc
+++ b/cfg/valve.rc
@@ -1,5 +1,25 @@
-    // Exec default autoexec file
+    ////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Default commands
+    ////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Run user script files
+    exec joystick.cfg
     exec autoexec.cfg
+
+    // Parse and stuff command line + commands to command buffer
+    stuffcmds
+
+    // Open initial menu screen and load the background bsp,
+    // but only if no other level is being loaded, and we're not in developer mode
+    startupmenu
+
+    // Not used anymore, according to mastercoms
+    // (previously was used long ago to use the CPU to scan for small decals to stop rendering)
+    // Default: 5
+    r_decal_cullsize                                                1
+
+    // Allow menu backgrounds to display randomly by unlocking all chapters
+    // Default: 1
+    sv_unlockedchapters                                             99
 
     echo ;
     echo ;
@@ -45,8 +65,8 @@
     con_filter_text_out                                             "Couldn't find script file"
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////
-    // Commands recommended by mastercomms
+    // Commands recommended by mastercoms
     ////////////////////////////////////////////////////////////////////////////////////////////////////
     // This is the interp for the payload HUD updates
     // Default: 0.2
-    hud_escort_interp 0.1
+    hud_escort_interp                                               0.1


### PR DESCRIPTION
Closes https://github.com/rbjaxter/budhud/issues/547

Some info about those commands:
- `r_decal_cullsize`:
https://github.com/mastercomfig/mastercomfig/commit/1d63b4106f53cf13625049374fc0fb8da0842983
https://github.com/mastercomfig/mastercomfig/blob/4f070469df3e970c90d097893d13ea7073a63953/docs/tf2/misconceptions.md?plain=1#L73
- `stuffcmds` and `startupmenu`:
https://discord.com/channels/389089828249010188/1072696252162117752/1171333191492173904
https://discord.com/channels/673304949718908948/687351019637702731/1249944370996838511
(but from my few tests, neither of the two of them are required for the game to work properly)
- `sv_unlockedchapters`:
https://discord.com/channels/673304949718908948/687351019637702731/1057735573374238720