### PR TITLE
Match colors used in `AddToCartBlink` event to current color theme

### DIFF
--- a/_budhud/scripts/hudanimations_budhud.txt
+++ b/_budhud/scripts/hudanimations_budhud.txt
@@ -546,3 +546,27 @@ event NotificationsPresentBlinkStop
     StopEvent            NotificationsPresentBlinkLoop            0.0
     Animate              NotificationsPresentPanel                alpha            255            Linear            0.0            0.0
 }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Makes CartButton blink when an item is added to the cart
+// The colors are matched to the current color theme, keeping the animation unchanged
+////////////////////////////////////////////////////////////////////////////////////////////////////
+event AddToCartBlink
+{
+    Animate            CartButton            bgcolor            bh_Theme_BG20            Linear            0.0            0.01
+    Animate            CartButton            bgcolor            bh_orange                Linear            0.1            0.01
+
+    Animate            CartButton            bgcolor            bh_Theme_BG20            Linear            0.2            0.01
+    Animate            CartButton            bgcolor            bh_orange                Linear            0.3            0.01
+
+    Animate            CartButton            bgcolor            bh_Theme_BG20            Linear            0.4            0.01
+    Animate            CartButton            bgcolor            bh_orange                Linear            0.5            0.01
+
+    Animate            CartButton            bgcolor            bh_Theme_BG20            Linear            0.6            0.01
+    Animate            CartButton            bgcolor            bh_orange                Linear            0.7            0.01
+
+    Animate            CartButton            bgcolor            bh_Theme_BG20            Linear            0.8            0.01
+    Animate            CartButton            bgcolor            bh_orange                Linear            0.9            0.01
+
+    Animate            CartButton            bgcolor            bh_Theme_BG20            Linear            1.0            0.01
+}

--- a/_budhud/scripts/hudanimations_budhud.txt
+++ b/_budhud/scripts/hudanimations_budhud.txt
@@ -553,20 +553,20 @@ event NotificationsPresentBlinkStop
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 event AddToCartBlink
 {
-    Animate            CartButton            bgcolor            bh_Theme_BG20            Linear            0.0            0.01
-    Animate            CartButton            bgcolor            bh_orange                Linear            0.1            0.01
+    Animate            CartButton            bgcolor            bh_Theme_BG20                  Linear            0.0            0.01
+    Animate            CartButton            bgcolor            bh_Theme_TextAccent            Linear            0.1            0.01
 
-    Animate            CartButton            bgcolor            bh_Theme_BG20            Linear            0.2            0.01
-    Animate            CartButton            bgcolor            bh_orange                Linear            0.3            0.01
+    Animate            CartButton            bgcolor            bh_Theme_BG20                  Linear            0.2            0.01
+    Animate            CartButton            bgcolor            bh_Theme_TextAccent            Linear            0.3            0.01
 
-    Animate            CartButton            bgcolor            bh_Theme_BG20            Linear            0.4            0.01
-    Animate            CartButton            bgcolor            bh_orange                Linear            0.5            0.01
+    Animate            CartButton            bgcolor            bh_Theme_BG20                  Linear            0.4            0.01
+    Animate            CartButton            bgcolor            bh_Theme_TextAccent            Linear            0.5            0.01
 
-    Animate            CartButton            bgcolor            bh_Theme_BG20            Linear            0.6            0.01
-    Animate            CartButton            bgcolor            bh_orange                Linear            0.7            0.01
+    Animate            CartButton            bgcolor            bh_Theme_BG20                  Linear            0.6            0.01
+    Animate            CartButton            bgcolor            bh_Theme_TextAccent            Linear            0.7            0.01
 
-    Animate            CartButton            bgcolor            bh_Theme_BG20            Linear            0.8            0.01
-    Animate            CartButton            bgcolor            bh_orange                Linear            0.9            0.01
+    Animate            CartButton            bgcolor            bh_Theme_BG20                  Linear            0.8            0.01
+    Animate            CartButton            bgcolor            bh_Theme_TextAccent            Linear            0.9            0.01
 
-    Animate            CartButton            bgcolor            bh_Theme_BG20            Linear            1.0            0.01
+    Animate            CartButton            bgcolor            bh_Theme_BG20                  Linear            1.0            0.01
 }


### PR DESCRIPTION
Before:
![before](https://github.com/user-attachments/assets/158fa021-c76f-4067-869b-f218dbf11040)

After:
![after](https://github.com/user-attachments/assets/996c31e9-f0d7-4473-953a-b228d1501c63)