### PR TITLE
Fix order of `#base` statements

### DIFF
--- a/resource/ui/controlpointprogressbar.res
+++ b/resource/ui/controlpointprogressbar.res
@@ -1,5 +1,5 @@
-    #base    "../../#users/custom/#customization/_enabled/bh_player_showcontrolpointprogressbar.res"
     #base    "../../#users/custom/resource/ui/controlpointprogressbar.res"
+    #base    "../../#users/custom/#customization/_enabled/bh_player_showcontrolpointprogressbar.res"
     #base    "../../#customization/_enabled/bh_player_showcontrolpointprogressbar.res"
     #base    "../../_stream/resource/ui/controlpointprogressbar.res"
     #base    "../../_budhud/resource/ui/controlpointprogressbar.res"

--- a/resource/ui/hudmatchstatus.res
+++ b/resource/ui/hudmatchstatus.res
@@ -1,5 +1,5 @@
-    #base    "../../#users/custom/#customization/_enabled/bh_matchstatus_6v6.res"
     #base    "../../#users/custom/resource/ui/hudmatchstatus.res"
+    #base    "../../#users/custom/#customization/_enabled/bh_matchstatus_6v6.res"
     #base    "../../#customization/_enabled/bh_matchstatus_6v6.res"
     #base    "../../_stream/resource/ui/hudmatchstatus.res"
     #base    "../../_budhud/resource/ui/hudmatchstatus.res"


### PR DESCRIPTION
This order pattern is followed in all other files (and also seems more appropriate to me).