### PR TITLE
Fixed font issues on Linux clients

### DIFF
--- a/_budhud/resource/clientscheme_lato.res
+++ b/_budhud/resource/clientscheme_lato.res
@@ -265,7 +265,8 @@
             "1"
             {
                 "name"                                              "Lato Semibold"
-                "tall"                                              "6"
+                "tall"                                              "6" [!$POSIX]
+                "tall"                                              "7" [$POSIX]
                 "weight"                                            "500"
                 "antialias"                                         "1"
                 "dropshadow"                                        "0"
@@ -291,7 +292,8 @@
             "1"
             {
                 "name"                                              "Lato Semibold"
-                "tall"                                              "10"
+                "tall"                                              "10" [!$POSIX]
+                "tall"                                              "11" [$POSIX]
                 "weight"                                            "500"
                 "antialias"                                         "1"
                 "dropshadow"                                        "0"
@@ -515,7 +517,8 @@
             "1"
             {
                 "name"                                              "Lato Semibold"
-                "tall"                                              "6"
+                "tall"                                              "6" [!$POSIX]
+                "tall"                                              "7" [$POSIX]
                 "weight"                                            "500"
                 "antialias"                                         "1"
                 "dropshadow"                                        "1"
@@ -541,7 +544,8 @@
             "1"
             {
                 "name"                                              "Lato Semibold"
-                "tall"                                              "10"
+                "tall"                                              "10" [!$POSIX]
+                "tall"                                              "11" [$POSIX]
                 "weight"                                            "500"
                 "antialias"                                         "1"
                 "dropshadow"                                        "1"
@@ -765,7 +769,8 @@
             "1"
             {
                 "name"                                              "Lato Semibold"
-                "tall"                                              "6"
+                "tall"                                              "6" [!$POSIX]
+                "tall"                                              "7" [$POSIX]
                 "weight"                                            "500"
                 "antialias"                                         "1"
                 "dropshadow"                                        "0"
@@ -791,7 +796,8 @@
             "1"
             {
                 "name"                                              "Lato Semibold"
-                "tall"                                              "10"
+                "tall"                                              "10" [!$POSIX]
+                "tall"                                              "11" [$POSIX]
                 "weight"                                            "500"
                 "antialias"                                         "1"
                 "dropshadow"                                        "0"
@@ -2457,7 +2463,8 @@
             "1"
             {
                 "name"                                              "Lato Semibold"
-                "tall"                                              "10"
+                "tall"                                              "10" [!$POSIX]
+                "tall"                                              "11" [$POSIX]
                 "weight"                                            "400"
                 "additive"                                          "0"
                 "antialias"                                         "1"

--- a/_budhud/resource/clientscheme_lato.res
+++ b/_budhud/resource/clientscheme_lato.res
@@ -2250,7 +2250,8 @@
             "1"
             {
                 "name"                                              "Lato Semibold"
-                "tall"                                              "10"
+                "tall"                                              "10" [!$POSIX]
+                "tall"                                              "11" [$POSIX]
                 "tall_hidef"                                        "12"
                 "tall_lodef"                                        "14"
                 "weight"                                            "400"

--- a/_budhud/resource/clientscheme_lato.res
+++ b/_budhud/resource/clientscheme_lato.res
@@ -2235,7 +2235,8 @@
         {
             "1"
             {
-                "name"                                              "Lato Semibold"
+                "name"                                              "Lato Semibold" [!$POSIX]
+                "name"                                              "Verdana" [$POSIX]
                 "tall"                                              "8"
                 "tall_hidef"                                        "10"
                 "tall_lodef"                                        "14"

--- a/_budhud/resource/sourcescheme.res
+++ b/_budhud/resource/sourcescheme.res
@@ -315,8 +315,7 @@
         {
             "1"
             {
-                "name"                                              "Lucida Console" [!$POSIX]
-                "name"                                              "Verdana" [$POSIX]
+                "name"                                              "Lucida Console"    //Monospaced
                 "tall"                                              "12"
                 "antialias"                                         "1"
             }


### PR DESCRIPTION
Used [$POSIX] strings to not findle with Windows configurations, which are fine as is.

### It fixes:

- Party chat text
- Steam Friends' names text in main menu
- Filtering buttons text in the Backpack 
- Team selection keybinds and numbers
- Item meter texts in-game
- Stats Page's Class entries text
- Developer Console text 