### PR TITLE
Fix transparency issue when inspecting a weapon with skins

### DIFF
--- a/_budhud/resource/ui/hudinspectpanel.res
+++ b/_budhud/resource/ui/hudinspectpanel.res
@@ -34,7 +34,7 @@
 
         "itemmodelpanel"
         {
-            "useparentbg"                                           "0"
+            "useparentbg"                                           "1"
             "allow_rot"                                             "0"
             "inventory_image_type"                                  "1"
             "use_item_rendertarget"                                 "0"


### PR DESCRIPTION
Used to display a full green box, fixes #582 