### PR TITLE
Fix issue with tabs on Backpack and Store pages, appearing after the latest TF2 update

### DIFF
--- a/_budhud/resource/ui/charinfopanel.res
+++ b/_budhud/resource/ui/charinfopanel.res
@@ -80,7 +80,7 @@
         "tall"                                                      "f0"
         "titlebarfgcolor_override"                                  "bh_white"
         "titlebardisabledfgcolor_override"                          "bh_white"
-        "titletextinsetY"                                           "10"
+        "titletextinsetY"                                           "-4"
     }
 
     "Sheet"
@@ -95,7 +95,7 @@
         "HeaderLine"
         {
             "ControlName"                                           "EditablePanel"
-            "ypos"                                                  "19" // no s or p
+            "ypos"                                                  "34" // = "tabheight" + "yoffset". no s or p
             "zpos"                                                  "101"
             "border"                                                "bh_b_N"
         }

--- a/_budhud/resource/ui/charinfopanel.res
+++ b/_budhud/resource/ui/charinfopanel.res
@@ -80,23 +80,26 @@
         "tall"                                                      "f0"
         "titlebarfgcolor_override"                                  "bh_white"
         "titlebardisabledfgcolor_override"                          "bh_white"
-        "titletextinsetY"                                           "-4"
+        "titletextinsetY"                                           "10"
     }
 
     "Sheet"
     {
-        "tabxindent"                                                "80"        // Tab left/right position
-        "tabxdelta"                                                 "10"        // Gap between tabs
-        "tabwidth"                                                  "240"       // Tab width
-        "tabheight"                                                 "20"        // Tab height
-        "transition_time"                                           "0"         // Fade in between tabs
-        "yoffset"                                                   "14"        // Tab distance from top of screen
+        "tabxindent"                                                "80"  // Tab left/right position
+        "tabxdelta"                                                 "10"  // Gap between tabs
+        "tabwidth"                                                  "240" // Tab width
+        "tabheight"                                                 "20"  // Tab height
+        "transition_time"                                           "0"   // Fade in between tabs
+
+        "yoffset"                                                   "0" // keep at 0 (use "titletextinsetY" for vertical adjustments of whole panel instead)
 
         "HeaderLine"
         {
             "ControlName"                                           "EditablePanel"
-            "ypos"                                                  "34" // = "tabheight" + "yoffset". no s or p
+            "ypos"                                                  "20" // = "tabheight". no s or p
             "zpos"                                                  "101"
+            "tall"                                                  "2"
+            "bgcolor_override"                                      "bh_blank"
             "border"                                                "bh_b_N"
         }
 

--- a/_budhud/resource/ui/econ/store/v2/storepanel.res
+++ b/_budhud/resource/ui/econ/store/v2/storepanel.res
@@ -150,7 +150,7 @@
         "bgcolor_override"                                          "bh_Theme_BG20"
         "infocus_bgcolor_override"                                  "bh_Theme_BG20"
         "outoffocus_bgcolor_override"                               "bh_Theme_BG20"
-        "titletextinsetY"                                           "10"
+        "titletextinsetY"                                           "-4"
     }
 
     "Sheet"
@@ -158,7 +158,7 @@
         "HeaderLine"
         {
             "ControlName"                                           "EditablePanel"
-            "ypos"                                                  "19" // no s or p
+            "ypos"                                                  "34" // = "tabheight" + "yoffset". no s or p
             "zpos"                                                  "101"
             "tall"                                                  "2"
             "bgcolor_override"                                      "bh_blank"

--- a/_budhud/resource/ui/econ/store/v2/storepanel.res
+++ b/_budhud/resource/ui/econ/store/v2/storepanel.res
@@ -150,15 +150,23 @@
         "bgcolor_override"                                          "bh_Theme_BG20"
         "infocus_bgcolor_override"                                  "bh_Theme_BG20"
         "outoffocus_bgcolor_override"                               "bh_Theme_BG20"
-        "titletextinsetY"                                           "-4"
+        "titletextinsetY"                                           "10"
     }
 
     "Sheet"
     {
+        "tabxindent"                                                "80"  // Tab left/right position
+        "tabxdelta"                                                 "3"   // Gap between tabs
+        "tabwidth"                                                  "240" // Tab width
+        "tabheight"                                                 "20"  // Tab height
+        "transition_time"                                           "0"   // Fade in between tabs
+
+        "yoffset"                                                   "0" // keep at 0 (use "titletextinsetY" for vertical adjustments of whole panel instead)
+
         "HeaderLine"
         {
             "ControlName"                                           "EditablePanel"
-            "ypos"                                                  "34" // = "tabheight" + "yoffset". no s or p
+            "ypos"                                                  "20" // = "tabheight". no s or p
             "zpos"                                                  "101"
             "tall"                                                  "2"
             "bgcolor_override"                                      "bh_blank"

--- a/_budhud/resource/ui/replaybrowser/mainpanel.res
+++ b/_budhud/resource/ui/replaybrowser/mainpanel.res
@@ -88,18 +88,20 @@
     {
         "ControlName"                                               "EditablePanel"
         "fieldName"                                                 "Sheet"
-        "tabxindent"                                                "80"
-        "tabxdelta"                                                 "10"
-        "tabwidth"                                                  "240"
-        "tabheight"                                                 "20"
-        "transition_time"                                           "0"
+        "tabxindent"                                                "80"  // Tab left/right position
+        "tabxdelta"                                                 "10"  // Gap between tabs
+        "tabwidth"                                                  "240" // Tab width
+        "tabheight"                                                 "20"  // Tab height
+        "transition_time"                                           "0"   // Fade in between tabs
+
+        "yoffset"                                                   "0" // keep at 0 (use "titletextinsetY" for vertical adjustments of whole panel instead)
 
         "HeaderLine"
         {
             "ControlName"                                           "EditablePanel"
             "fieldName"                                             "HeaderLine"
             "xpos"                                                  "0"
-            "ypos"                                                  "19" // no s or p
+            "ypos"                                                  "20" // = "tabheight". no s or p
             "zpos"                                                  "101"
             "wide"                                                  "f0"
             "tall"                                                  "2"


### PR DESCRIPTION
It follows up #590.

The replay page appears unaffected by the latest update.

EDIT: Thanks to @Wh1t3st4r for testing the patch on 4k :)