### PR TITLE
Make all player status icons the same size (32x32)

### DIFF
--- a/_budhud/resource/ui/hudplayerhealth.res
+++ b/_budhud/resource/ui/hudplayerhealth.res
@@ -133,150 +133,210 @@
     "PlayerStatusBleedImage"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatusHookBleedImage"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatusMilkImage"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatusGasImage"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatusMarkedForDeathImage"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatusMarkedForDeathSilentImage"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_MedicUberBulletResistImage"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_MedicUberBlastResistImage"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_MedicUberFireResistImage"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_MedicSmallBulletResistImage"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_MedicSmallBlastResistImage"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_MedicSmallFireResistImage"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_SoldierOffenseBuff"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_SoldierDefenseBuff"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_SoldierHealOnHitBuff"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_SpyMarked"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_Parachute"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_RuneStrength"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_RuneHaste"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_RuneRegen"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_RuneResist"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_RuneVampire"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_RuneReflect"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_RunePrecision"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_RuneAgility"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_RuneKnockout"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_RuneKing"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_RunePlague"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatus_RuneSupernova"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 
     "PlayerStatusSlowed"
     {
         "pin_to_sibling"                                            "bh_PlayerStatusPin"
+        "wide"                                                      "32"
+        "tall"                                                      "32"
     }
 }


### PR DESCRIPTION
In the default HUD, some icons are 31x31 while others are 32x32. Only the 32x32 icons are properly aligned with health numbers in the current setup; the 31x31 ones appear slightly offset.

---

Before (1080p):

```
"PlayerStatusBleedImage"
{
	"wide"			"32"
	"tall"			"32"
}
```
![7HM1oDkc0n](https://github.com/user-attachments/assets/ae43bd8c-e04c-47bf-a435-bf09eae61c86)

```
"PlayerStatus_MedicUberBulletResistImage"
{
	"wide"			"31"
	"tall"			"31"
}
```
![ShareX_iSVFrDBriU](https://github.com/user-attachments/assets/236e5aee-b4e6-4577-b9b1-20a26f636634)

---

After (1080p):

```
"PlayerStatus_MedicUberBulletResistImage"
{
	"wide"			"32"
	"tall"			"32"
}
```
![0mggZF4y6c](https://github.com/user-attachments/assets/354a6c14-cd53-427e-9b85-e6f1ad151c9f)