### PR TITLE
Hide `Gradient` on `TopBar` of `MatchMakingDashboard`

### DIFF
--- a/_budhud/resource/ui/matchmakingdashboard.res
+++ b/_budhud/resource/ui/matchmakingdashboard.res
@@ -10,13 +10,6 @@
 
     "TopBar"
     {
-        "OuterShadow"
-        {
-            "ypos"                                                  "r-6969"
-            "visible"                                               "0"
-            "enabled"                                               "0"
-        }
-
         "FindAGameButton"
         {
             "wide"                                                  "50"
@@ -127,6 +120,13 @@
                 "tall"                                              "10"
                 "image"                                             "replay/thumbnails/menu_icons/x"
             }
+        }
+
+        "Gradient"
+        {
+            "ypos"                                                  "r-6969"
+            "visible"                                               "0"
+            "enabled"                                               "0"
         }
 
         "BGPanel"


### PR DESCRIPTION
I also removed duplicated `OuterShadow` entry.

---

Before (It might be hard to notice but the gradient is there 😄):

![ygYJ89TXv5](https://github.com/user-attachments/assets/dca914b8-c962-4717-939c-db79492ec276)

---

After:

![LPrg5zINEu](https://github.com/user-attachments/assets/63366c5d-8098-4372-ab06-ef7006720769)