### PR TITLE
Refactor `classmodelpanel` to improve code clarity and stability

### DIFF
--- a/#customization/bh_player_hideclassmodel.res
+++ b/#customization/bh_player_hideclassmodel.res
@@ -11,7 +11,7 @@
         "enabled"                                                   "0"
     }
 
-    "bh_classmodelpanel"
+    "classmodelpanel"
     {
         "ypos"                                                      "r-6969"
         "visible"                                                   "0"

--- a/#dev/bh_dev_fontcharactersettesting.res
+++ b/#dev/bh_dev_fontcharactersettesting.res
@@ -1,6 +1,6 @@
 "Resource/UI/HudPlayerClass.res"
 {
-    "bh_classmodelpanel"
+    "classmodelpanel"
     {
         "ypos"                                                      "r-6969"
         "visible"                                                   "0"

--- a/#users/jayhyunpae_/#customization/_enabled/bh_player_hideclassmodel.res
+++ b/#users/jayhyunpae_/#customization/_enabled/bh_player_hideclassmodel.res
@@ -11,7 +11,7 @@
         "enabled"                                                   "0"
     }
 
-    "bh_classmodelpanel"
+    "classmodelpanel"
     {
         "ypos"                                                      "r-6969"
         "visible"                                                   "0"

--- a/_budhud/resource/ui/hudplayerclass.res
+++ b/_budhud/resource/ui/hudplayerclass.res
@@ -21,13 +21,6 @@
         "enabled"                                                   "0"
     }
 
-    "classmodelpanel"
-    {
-        "ypos"                                                      "r-6969"
-        "visible"                                                   "0"
-        "enabled"                                                   "0"
-    }
-
     "PlayerStatusClassImage"
     {
         "xpos"                                                      "50"
@@ -70,35 +63,130 @@
     }
     ////////////////////////////////////////////////////////////////////////////////////////////////////
     // Controls 3d player model
-    // Does not appear you can use `customclassdata` when using #base here
     ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    "bh_classmodelpanel"
+    "classmodelpanel"
     {
-        "ControlName"                                               "CTFPlayerModelPanel"
-        "fieldName"                                                 "classmodelpanel"
         "xpos"                                                      "0"
         "ypos"                                                      "r180"
-        "zpos"                                                      "2"
         "wide"                                                      "200"
         "tall"                                                      "300"
-        "autoResize"                                                "0"
-        "pinCorner"                                                 "0"
-        "visible"                                                   "1"
-        "enabled"                                                   "1"
-        "render_texture"                                            "0"
         "fov"                                                       "35"	// Higher FoV causes distortion
-        "allow_rot"                                                 "0"
 
         "model"
         {
-            "force_pos"                                             "1"
             "angles_x"                                              "0"
             "angles_y"                                              "210"	// 180 faces directly at user
             "angles_z"                                              "0"
             "origin_x"                                              "200"	// Move towards and away relative to user
             "origin_y"                                              "000"	// Move left/right relative to user (center: 0)
             "origin_z"                                              "-50"	// Move up/down relative to user (center: 40ish)
+        }
+
+        "customclassdata"
+        {
+            "undefined"
+            {
+            }
+
+            "Scout"
+            {
+                "fov"                                               "35"	// Higher FoV causes distortion
+                "angles_x"                                          "0"
+                "angles_y"                                          "210"	// 180 faces directly at user
+                "angles_z"                                          "0"
+                "origin_x"                                          "200"	// Move towards and away relative to user
+                "origin_y"                                          "000"	// Move left/right relative to user (center: 0)
+                "origin_z"                                          "-50"	// Move up/down relative to user (center: 40ish)
+            }
+
+            "Sniper"
+            {
+                "fov"                                               "35"	// Higher FoV causes distortion
+                "angles_x"                                          "0"
+                "angles_y"                                          "210"	// 180 faces directly at user
+                "angles_z"                                          "0"
+                "origin_x"                                          "200"	// Move towards and away relative to user
+                "origin_y"                                          "000"	// Move left/right relative to user (center: 0)
+                "origin_z"                                          "-50"	// Move up/down relative to user (center: 40ish)
+            }
+
+            "Soldier"
+            {
+                "fov"                                               "35"	// Higher FoV causes distortion
+                "angles_x"                                          "0"
+                "angles_y"                                          "210"	// 180 faces directly at user
+                "angles_z"                                          "0"
+                "origin_x"                                          "200"	// Move towards and away relative to user
+                "origin_y"                                          "000"	// Move left/right relative to user (center: 0)
+                "origin_z"                                          "-50"	// Move up/down relative to user (center: 40ish)
+            }
+
+            "Demoman"
+            {
+                "fov"                                               "35"	// Higher FoV causes distortion
+                "angles_x"                                          "0"
+                "angles_y"                                          "210"	// 180 faces directly at user
+                "angles_z"                                          "0"
+                "origin_x"                                          "200"	// Move towards and away relative to user
+                "origin_y"                                          "000"	// Move left/right relative to user (center: 0)
+                "origin_z"                                          "-50"	// Move up/down relative to user (center: 40ish)
+            }
+
+            "Medic"
+            {
+                "fov"                                               "35"	// Higher FoV causes distortion
+                "angles_x"                                          "0"
+                "angles_y"                                          "210"	// 180 faces directly at user
+                "angles_z"                                          "0"
+                "origin_x"                                          "200"	// Move towards and away relative to user
+                "origin_y"                                          "000"	// Move left/right relative to user (center: 0)
+                "origin_z"                                          "-50"	// Move up/down relative to user (center: 40ish)
+            }
+
+            "Heavy"
+            {
+                "fov"                                               "35"	// Higher FoV causes distortion
+                "angles_x"                                          "0"
+                "angles_y"                                          "210"	// 180 faces directly at user
+                "angles_z"                                          "0"
+                "origin_x"                                          "200"	// Move towards and away relative to user
+                "origin_y"                                          "000"	// Move left/right relative to user (center: 0)
+                "origin_z"                                          "-50"	// Move up/down relative to user (center: 40ish)
+            }
+
+            "Pyro"
+            {
+                "fov"                                               "35"	// Higher FoV causes distortion
+                "angles_x"                                          "0"
+                "angles_y"                                          "210"	// 180 faces directly at user
+                "angles_z"                                          "0"
+                "origin_x"                                          "200"	// Move towards and away relative to user
+                "origin_y"                                          "000"	// Move left/right relative to user (center: 0)
+                "origin_z"                                          "-50"	// Move up/down relative to user (center: 40ish)
+            }
+
+            "Spy"
+            {
+                "fov"                                               "35"	// Higher FoV causes distortion
+                "angles_x"                                          "0"
+                "angles_y"                                          "210"	// 180 faces directly at user
+                "angles_z"                                          "0"
+                "origin_x"                                          "200"	// Move towards and away relative to user
+                "origin_y"                                          "000"	// Move left/right relative to user (center: 0)
+                "origin_z"                                          "-50"	// Move up/down relative to user (center: 40ish)
+            }
+
+            "Engineer"
+            {
+                "fov"                                               "35"	// Higher FoV causes distortion
+                "angles_x"                                          "0"
+                "angles_y"                                          "210"	// 180 faces directly at user
+                "angles_z"                                          "0"
+                "origin_x"                                          "200"	// Move towards and away relative to user
+                "origin_y"                                          "000"	// Move left/right relative to user (center: 0)
+                "origin_z"                                          "-50"	// Move up/down relative to user (center: 40ish)
+            }
         }
     }
 }


### PR DESCRIPTION
The panel can now be reliably modified via `#users/custom` without self-breaking behavior.