### PR TITLE
Improvements to `ItemQuickSwitch`

### DIFF
--- a/_budhud/resource/ui/itemquickswitch.res
+++ b/_budhud/resource/ui/itemquickswitch.res
@@ -7,13 +7,6 @@
         "enabled"                                                   "0"
     }
 
-    "ItemSlotLabel"
-    {
-        "ypos"                                                      "r-6969"
-        "visible"                                                   "0"
-        "enabled"                                                   "0"
-    }
-
     "TopLine"
     {
         "ypos"                                                      "r-6969"
@@ -40,13 +33,20 @@
 
     "ClassLabel"
     {
-        "font"                                                      "bh_Font12"
-        "textAlignment"                                             "west"
         "xpos"                                                      "6"
-        "ypos"                                                      "5"
-        "zpos"                                                      "1"
-        "wide"                                                      "60"
-        "tall"                                                      "15"
+        "auto_wide_tocontents"                                      "1"
+        "font"                                                      "bh_Font12"
+    }
+
+    "ItemSlotLabel"
+    {
+        "pin_to_sibling"                                            "ClassLabel"
+        "pin_corner_to_sibling"                                     "PIN_CENTER_LEFT"
+        "pin_to_sibling_corner"                                     "PIN_CENTER_RIGHT"
+        "xpos"                                                      "2"
+        "ypos"                                                      "0"
+        "auto_wide_tocontents"                                      "1"
+        "font"                                                      "bh_Font12"
     }
 
     "itemcontainerscroller"


### PR DESCRIPTION
Before:

<img src="https://github.com/user-attachments/assets/6e09196e-d529-4fd9-9a59-44b31545b887" width="500" height="300">
<img src="https://github.com/user-attachments/assets/f562091f-f4b3-4e35-bccd-ce4138b1e1f9" width="500" height="300">

---

After:

<img src="https://github.com/user-attachments/assets/e1a7e9d5-0b00-4fe2-b27e-fc00352ce0ac" width="500" height="300">
<img src="https://github.com/user-attachments/assets/96162df8-6213-4900-8d8d-22e0a6f04432" width="500" height="300">
