### PR TITLE
Improve `sourcescheme` color theme and fix overlapping border edges

### DIFF
--- a/_budhud/resource/sourcescheme.res
+++ b/_budhud/resource/sourcescheme.res
@@ -62,9 +62,9 @@
         "TFTanLightBright"                                          "255 192 203 090"	// Unknown
         "TFTanLightDark"                                            "255 255 255 050"	// Inner outline color
         "TFOrangeBright"                                            "100 100 100 150"	// Context menu highlight
-        "TFTextBright"                                              "255 255 255 150"	// Main text color (servers, filters, etc; not console)
-        "TFTextMedium"                                              "255 255 255 255"	// "Team Fortress 2" text in Game dropdown (??)
-        "TFTextDull"                                                "255 255 255 255"	// Quick Refresh + Game arrow color (in server browser)
+        "TFTextBright"                                              "255 255 255 255"	// Main text color (servers, filters, etc; not console)
+        "TFTextMedium"                                              "240 134 049 255"	// Highlighted text color (checkboxes)
+        "TFTextDull"                                                "125 125 125 255"	// Inactive text color (buttons, checkboxes)
         // Background colors
         "ControlBG"                                                 "050 050 050 255"	// background color of controls
         "ControlDarkBG"                                             "050 050 050 255"	// darker background color; used for background of scrollbars
@@ -76,16 +76,26 @@
 
     "BaseSettings"
     {
+        "Border.Bright"                                             "bh_white_t"
+        "Border.Dark"                                               "bh_white_t"
+        "Button.TextColor"                                          "bh_white"
+        "Button.BgColor"                                            "bh_Theme_BG40"
+        "Button.ArmedTextColor"                                     "bh_Theme_TextAccent"
+        "Button.ArmedBgColor"                                       "bh_Theme_BG60"
+        "Button.DepressedTextColor"                                 "bh_white_t"
+        "Button.DepressedBgColor"                                   "bh_Theme_BG30"
         "Console.TextColor"                                         "bh_yellow"	// Color of entered console commands
         "Console.DevTextColor"                                      "bh_IsError"	// Unknown
         // Game join loading bar
         "Frame.BgColor"                                             "bh_Theme_BG30"
-        "Frame.OutOfFocusBGColor"                                   "bh_Theme_BG30"
+        "Frame.OutOfFocusBGColor"                                   "bh_Theme_BG20"
+        "PropertySheet.TextColor"                                   "bh_white_t"
+        "PropertySheet.SelectedTextColor"                           "bh_white"
         // All boxes you can type into
         "TextEntry.TextColor"                                       "bh_white"
         "TextEntry.BgColor"                                         "bh_Theme_BG20"
         "TextEntry.CursorColor"                                     "bh_white"
-        "TextEntry.DisabledTextColor"                               "bh_white"
+        "TextEntry.DisabledTextColor"                               "TFTextDull"
         "TextEntry.DisabledBgColor"                                 "bh_Theme_BG20"
         "TextEntry.SelectedTextColor"                               "bh_black"
         "TextEntry.SelectedBgColor"                                 "bh_Theme_TextAccent"
@@ -142,6 +152,221 @@
                         "color"                                     "bh_blue"
                         "offset"                                    "0 1"
                     }
+                }
+            }
+        }
+
+        "FrameBorder"
+        {
+            "backgroundtype"                                        "0"
+            "proportional_scalar"                                   "0.5"
+
+            "Left"
+            {
+                "1"
+                {
+                    "color"                                         "bh_BGStandard"
+                    "offset"                                        "0 1"
+                }
+            }
+
+            "Right"
+            {
+                "1"
+                {
+                    "color"                                         "bh_BGStandard"
+                    "offset"                                        "1 0"
+                }
+            }
+
+            "Top"
+            {
+                "1"
+                {
+                    "color"                                         "bh_BGStandard"
+                    "offset"                                        "1 0"
+                }
+            }
+
+            "Bottom"
+            {
+                "1"
+                {
+                    "color"                                         "bh_BGStandard"
+                    "offset"                                        "0 1"
+                }
+            }
+        }
+
+        "RaisedBorder"
+        {
+            "proportional_scalar"                                   "0.5"
+
+            "Left"
+            {
+                "1"
+                {
+                    "offset"                                        "0 1"
+                }
+            }
+
+            "Right"
+            {
+                "1"
+                {
+                    "offset"                                        "1 0"
+                }
+            }
+
+            "Top"
+            {
+                "1"
+                {
+                    "offset"                                        "1 0"
+                }
+            }
+
+            "Bottom"
+            {
+                "1"
+                {
+                    "offset"                                        "0 1"
+                }
+            }
+        }
+
+        "ButtonKeyFocusBorder"
+        {
+            "proportional_scalar"                                   "0.5"
+
+            "Left"
+            {
+                "1"
+                {
+                    "color"                                         "Border.Bright"
+                    "offset"                                        "0 1"
+                }
+
+                "2"
+                {
+                    "color"                                         "bh_blank"
+                }
+            }
+
+            "Right"
+            {
+                "1"
+                {
+                    "color"                                         "Border.Dark"
+                    "offset"                                        "1 0"
+                }
+
+                "2"
+                {
+                    "color"                                         "bh_blank"
+                }
+            }
+
+            "Top"
+            {
+                "1"
+                {
+                    "color"                                         "Border.Bright"
+                    "offset"                                        "1 0"
+                }
+
+                "2"
+                {
+                    "color"                                         "bh_blank"
+                }
+            }
+
+            "Bottom"
+            {
+                "1"
+                {
+                    "color"                                         "Border.Dark"
+                    "offset"                                        "0 1"
+                }
+
+                "2"
+                {
+                    "color"                                         "bh_blank"
+                }
+            }
+        }
+
+        "ButtonDepressedBorder"
+        {
+            "proportional_scalar"                                   "0.5"
+
+            "Left"
+            {
+                "1"
+                {
+                    "offset"                                        "0 1"
+                }
+            }
+
+            "Right"
+            {
+                "1"
+                {
+                    "offset"                                        "1 0"
+                }
+            }
+
+            "Top"
+            {
+                "1"
+                {
+                    "offset"                                        "1 0"
+                }
+            }
+
+            "Bottom"
+            {
+                "1"
+                {
+                    "offset"                                        "0 1"
+                }
+            }
+        }
+
+        "TabActiveBorder"
+        {
+            "proportional_scalar"                                   "0.5"
+
+            "Left"
+            {
+                "1"
+                {
+                    "offset"                                        "0 1"
+                }
+            }
+
+            "Right"
+            {
+                "1"
+                {
+                    "offset"                                        "1 0"
+                }
+            }
+
+            "Top"
+            {
+                "1"
+                {
+                    "offset"                                        "1 0"
+                }
+            }
+
+            "Bottom"
+            {
+                "1"
+                {
+                    "color"                                         "Border.Dark"
+                    "offset"                                        "0 1"
                 }
             }
         }


### PR DESCRIPTION
These are the improvements to `sourcescheme` I mentioned on the Discord server a while back. I’ve been using them since then and haven’t run into any issues, so I figured I’d go ahead and submit a PR. That said, since I tuned the colors to my personal preference (and I play with mat_monitorgamma 1.6), some things might not be to your taste.

I’ve also included the recently discovered fix for 'thick' borders (`"proportional_scalar" "0.5"`).

---

Before:

<img src="https://github.com/user-attachments/assets/52fe1683-a821-45cc-8773-dd171b431152" width="500" height="auto">
<img src="https://github.com/user-attachments/assets/f3d84b7a-740b-4590-aaba-0879cddae77c" width="500" height="auto">

---

After:

<img src="https://github.com/user-attachments/assets/f38159ef-ca12-4b89-b3ea-b61c3dbccbf3" width="500" height="auto">
<img src="https://github.com/user-attachments/assets/48af5ced-b61e-4190-a1be-b7bd51dcec1b" width="500" height="auto">