### PR TITLE
Add missing inventory_image_type 1

### DIFF
--- a/_budhud/resource/ui/freezepanel_basic.res
+++ b/_budhud/resource/ui/freezepanel_basic.res
@@ -1,4 +1,4 @@
-#base                                                               "hudinspectpanel.res"	// Base to hudinspectpanel to grab its itempanel
+#base "hudinspectpanel.res"     // Base to hudinspectpanel to grab its itempanel
 
 "Resource/UI/FreezePanel_Basic.res"
 {
@@ -111,5 +111,12 @@
 
     "itempanel" // pin doesn't behave correctly
     {
+		"itemmodelpanel"
+		{
+			"fieldName"		              "itemmodelpanel"
+			"use_item_rendertarget"       "0"
+			"useparentbg"		          "1"
+			"inventory_image_type"        "1"
+		}
     }
 }

--- a/_budhud/resource/ui/freezepanel_basic.res
+++ b/_budhud/resource/ui/freezepanel_basic.res
@@ -1,4 +1,4 @@
-#base "hudinspectpanel.res"     // Base to hudinspectpanel to grab its itempanel
+"#base"                                                             "hudinspectpanel.res"	// Base to hudinspectpanel to grab its itempanel
 
 "Resource/UI/FreezePanel_Basic.res"
 {

--- a/_budhud/resource/ui/itemquickswitch.res
+++ b/_budhud/resource/ui/itemquickswitch.res
@@ -26,6 +26,11 @@
             "wide"                                                  "240"
             "model_xpos"                                            "0"
             "text_wide"                                             "180"
+
+            "itemmodelpanel"
+            {
+                "inventory_image_type"		"1"
+            }
         }
     }
 

--- a/_budhud/resource/ui/spectatortournament.res
+++ b/_budhud/resource/ui/spectatortournament.res
@@ -1,4 +1,4 @@
-"#base"                                                             "hudinspectpanel.res"	// Base to hudinspectpanel to grab its itempanel
+#base "hudinspectpanel.res"     // Base to hudinspectpanel to grab its itempanel
 
 "Resource/UI/SpectatorTournament.res"
 {

--- a/_budhud/resource/ui/spectatortournament.res
+++ b/_budhud/resource/ui/spectatortournament.res
@@ -1,4 +1,4 @@
-#base "hudinspectpanel.res"     // Base to hudinspectpanel to grab its itempanel
+"#base"                                                             "hudinspectpanel.res"	// Base to hudinspectpanel to grab its itempanel
 
 "Resource/UI/SpectatorTournament.res"
 {


### PR DESCRIPTION
This PR aims to address this comment here: https://github.com/rbjaxter/budhud/issues/600#issuecomment-3046980740
by adding the missing img type 1 to the offending files.

If I understand this correctly:

`freezepanel_basic.res`, `spectator.res` and `spectatortournament.res` do not need to add imgtype 1 because they have `#base "hudinspectpanel.res"` at the very top of the file, which brings the changes from `hudinspectpanel.res` to those files. Since `hudinspectpanel.res` already has imgtype 1, those three files should also have it due to `#base`.

However, `freezepanel_basic.res` has `itempanel` empty, as such:
```
"itempanel"
{
}
```
this makes me believe the `itempanel` from `hudinspectpanel.res` is not imported, since it is being overriden with an empty one. Due to that, I've added `itemmodelpanel` manually to it. This may be a misunderstanding on my part, but I think that is how the logic works.

And the final file, `itemquickswitch.res`, outright does not have it (neither in the original nor in the budhud file), so I've added manually. `"itemmodelpanel"` does not exist in the original, so I just added imgtype 1 without any other properties (I am sincerely not sure what they do, such as allow_rot).

I've also adjusted the comments at the top of the files to be consistent and use less space.

Thanks!