### PR TITLE
Fix console font size on Linux

### DIFF
--- a/_budhud/resource/sourcescheme.res
+++ b/_budhud/resource/sourcescheme.res
@@ -538,7 +538,6 @@
                 "tall"                                              "12" [!$LINUX]
                 "tall"                                              "14" [$LINUX]
                 "antialias"                                         "1"
-                "weight"                                            "500"
             }
         }
 

--- a/_budhud/resource/sourcescheme.res
+++ b/_budhud/resource/sourcescheme.res
@@ -498,8 +498,8 @@
             {
                 "name"                                              "Lato Semibold" [!$POSIX]
                 "name"                                              "Verdana" [$POSIX]
-				"tall"		                                        "16" [!$LINUX]
-				"tall"		                                        "18" [$LINUX]
+                "tall"                                              "16" [!$LINUX]
+                "tall"                                              "18" [$LINUX]
                 "antialias"                                         "1"
                 "weight"                                            "500"
             }
@@ -511,8 +511,8 @@
             {
                 "name"                                              "Lato Semibold" [!$POSIX]
                 "name"                                              "Verdana" [$POSIX]
-				"tall"		                                        "13" [!$POSIX]
-				"tall"		                                        "15" [$POSIX]
+                "tall"                                              "13" [!$POSIX]
+                "tall"                                              "15" [$POSIX]
                 "antialias"                                         "1"
                 "weight"                                            "500"
             }
@@ -535,8 +535,8 @@
             "1"
             {
                 "name"                                              "Lucida Console"	// Monospaced
-                "tall"		                                        "12" [!$LINUX]
-				"tall"		                                        "14" [$LINUX]
+                "tall"                                              "12" [!$LINUX]
+                "tall"                                              "14" [$LINUX]
                 "antialias"                                         "1"
                 "weight"                                            "500"
             }

--- a/_budhud/resource/sourcescheme.res
+++ b/_budhud/resource/sourcescheme.res
@@ -498,7 +498,8 @@
             {
                 "name"                                              "Lato Semibold" [!$POSIX]
                 "name"                                              "Verdana" [$POSIX]
-                "tall"                                              "16"
+				"tall"		                                        "16" [!$LINUX]
+				"tall"		                                        "18" [$LINUX]
                 "antialias"                                         "1"
                 "weight"                                            "500"
             }
@@ -510,7 +511,8 @@
             {
                 "name"                                              "Lato Semibold" [!$POSIX]
                 "name"                                              "Verdana" [$POSIX]
-                "tall"                                              "13"
+				"tall"		                                        "13" [!$POSIX]
+				"tall"		                                        "15" [$POSIX]
                 "antialias"                                         "1"
                 "weight"                                            "500"
             }
@@ -533,8 +535,10 @@
             "1"
             {
                 "name"                                              "Lucida Console"	// Monospaced
-                "tall"                                              "12"
+                "tall"		                                        "12" [!$LINUX]
+				"tall"		                                        "14" [$LINUX]
                 "antialias"                                         "1"
+                "weight"                                            "500"
             }
         }
 


### PR DESCRIPTION
I just copied some values from `platform/resource/sourceschemebase.res` into the budhud's `sourcescheme.res` file.

I also added a missing `weight` property for the console font.

I did not test this on Windows, but it should work without affecting Windows.
The macOS version of TF2 is not supported anymore, by the way.

Things I noticed:

- The top of the file does not have a `#base "SourceSchemeBase.res"`. Not sure if needed.
- The `resource/sourcescheme.res` has an empty descriptor with its file name. Not sure if it's needed.

# Before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/cf9c5fe3-2b0d-4cb5-9eeb-0c32d6f12dc8" />

# After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/dbb10bd8-9c64-4506-bb1f-10eeaeb5a97b" />