### PR TITLE
Adjust itemmodelpanel in freezepanel_basic.res

### DIFF
--- a/_budhud/resource/ui/freezepanel_basic.res
+++ b/_budhud/resource/ui/freezepanel_basic.res
@@ -111,12 +111,13 @@
 
     "itempanel" // pin doesn't behave correctly
     {
-		"itemmodelpanel"
-		{
-			"fieldName"		              "itemmodelpanel"
-			"use_item_rendertarget"       "0"
-			"useparentbg"		          "1"
-			"inventory_image_type"        "1"
-		}
+        "itemmodelpanel"
+        {
+            "fieldName"		                                        "itemmodelpanel"
+            "useparentbg"                                           "1"
+            "allow_rot"                                             "0"
+            "inventory_image_type"                                  "1"
+            "use_item_rendertarget"                                 "0"
+        }
     }
 }


### PR DESCRIPTION
Makes it match the itemmodelpanel from `hudinspectpanel.res` (it imports that file). Retain the fieldname thing because it's used in the default TF2 HUD.