### PR TITLE
Adjustments to some CFG files

### DIFF
--- a/cfg/bh_aliases.cfg
+++ b/cfg/bh_aliases.cfg
@@ -31,7 +31,7 @@
     echo "-------------";
     echo "- mat_phong 1";
     echo "- mat_bumpmap 1";
-    echo "- mat_picmip -1";
+    echo "- mat_picmip -10";
     echo "- bh_hardreload";
     echo " ";
     echo "Description";

--- a/cfg/bh_captions.cfg
+++ b/cfg/bh_captions.cfg
@@ -11,6 +11,7 @@
     cc_subtitles                                                    "0"
     cc_lang                                                         "/clovervidiar"
     cc_predisplay_time                                              "0"
+    cc_captiontrace                                                 "0"
 
     echo                                                            "//////////////////////////////"
     echo                                                            "Captions (by: clovervidia) set"

--- a/cfg/bh_captions_competitive.cfg
+++ b/cfg/bh_captions_competitive.cfg
@@ -11,6 +11,7 @@
     cc_subtitles                                                    "0"
     cc_lang                                                         "/clovervidiaw"
     cc_predisplay_time                                              "0"
+    cc_captiontrace                                                 "0"
 
     echo                                                            "////////////////////////////////////////////"
     echo                                                            "Captions - Competitive (by: clovervidia) set"

--- a/cfg/bh_captions_off.cfg
+++ b/cfg/bh_captions_off.cfg
@@ -8,6 +8,10 @@
 
     clear
     closecaption                                                    "0"
+    cc_subtitles                                                    "0"
+    cc_lang                                                         ""
+    cc_predisplay_time                                              "0.25"
+    cc_captiontrace                                                 "1"
 
     echo                                                            "///////////////////"
     echo                                                            "Captions - Disabled"

--- a/cfg/bh_stream_off.cfg
+++ b/cfg/bh_stream_off.cfg
@@ -12,7 +12,7 @@
     cl_spec_carrieditems                                            1
 
     // Enable killstreak notifications
-    cl_hud_killstreak_display_time                                  2
+    cl_hud_killstreak_display_time                                  3
 
     echo /////////////////////////////////////////////////
     echo Stream commands set

--- a/cfg/bh_stream_off.cfg
+++ b/cfg/bh_stream_off.cfg
@@ -1,17 +1,18 @@
     ////////////////////////////////////////////////////////////////////////////////////////////////////
     // Set default values for _stream hud commands
     ////////////////////////////////////////////////////////////////////////////////////////////////////
-    // Default text chat
+    // Default text chat time
     hud_saytext_time                                                12
 
-    //Enables voice chat
+    // Enable voice chat
     voice_modenable                                                 1
+    voice_enable                                                    1
 
     // Enable carried items while spectating
     cl_spec_carrieditems                                            1
 
     // Enable killstreak notifications
-    cl_hud_killstreak_display_time                                  1
+    cl_hud_killstreak_display_time                                  2
 
     echo /////////////////////////////////////////////////
     echo Stream commands set

--- a/cfg/bh_stream_off.cfg
+++ b/cfg/bh_stream_off.cfg
@@ -6,7 +6,6 @@
 
     // Enable voice chat
     voice_modenable                                                 1
-    voice_enable                                                    1
 
     // Enable carried items while spectating
     cl_spec_carrieditems                                            1

--- a/cfg/bh_stream_on.cfg
+++ b/cfg/bh_stream_on.cfg
@@ -4,16 +4,15 @@
     // Disable text chat
     hud_saytext_time                                                0
 
-    //Disable voice chat
+    // Disable voice chat
     voice_modenable                                                 0
+    voice_enable                                                    0
 
     // Disable carried items while spectating
     cl_spec_carrieditems                                            0
 
     // Disable killstreak notifications
     cl_hud_killstreak_display_time                                  0
-
-    //cl_hud_killstreak_display_fontsize?
 
     echo /////////////////////////////////////////////////
     echo Stream commands set

--- a/cfg/bh_stream_on.cfg
+++ b/cfg/bh_stream_on.cfg
@@ -6,7 +6,6 @@
 
     // Disable voice chat
     voice_modenable                                                 0
-    voice_enable                                                    0
 
     // Disable carried items while spectating
     cl_spec_carrieditems                                            0

--- a/cfg/bh_stream_on.cfg
+++ b/cfg/bh_stream_on.cfg
@@ -14,6 +14,8 @@
     // Disable killstreak notifications
     cl_hud_killstreak_display_time                                  0
 
+    //cl_hud_killstreak_display_fontsize?
+
     echo /////////////////////////////////////////////////
     echo Stream commands set
     echo /////////////////////////////////////////////////

--- a/cfg/valve.rc
+++ b/cfg/valve.rc
@@ -42,7 +42,7 @@ sv_unlockedchapters 99
     // game restart is sufficient to automatically reset such ones.
     ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    // Setting this to 0 can cause stuttering issues with Engineer PDAs (maybe Spy disguise as well?)
+    // Setting this to 0 can cause stuttering issues with Engineer PDAs (maybe spy disguise as well?)
     // Default: 1
     vgui_cache_res_files                                            1
 

--- a/cfg/valve.rc
+++ b/cfg/valve.rc
@@ -1,25 +1,84 @@
     ////////////////////////////////////////////////////////////////////////////////////////////////////
-    // Default commands
+    // HUD commands to run BEFORE user configurations.
+    // This way, we allow users to override them.
+    // "stored" means the values are saved in config.cfg, so you don't need to
+    // reset such ConVars if you uninstall budhud. If not specified, it is not stored, so a
+    // game restart is sufficient to automatically reset such ones.
     ////////////////////////////////////////////////////////////////////////////////////////////////////
-    // Run user script files
-    exec joystick.cfg
-    exec autoexec.cfg
 
-    // Parse and stuff command line + commands to command buffer
-    stuffcmds
+    // Any more would cause overlap due to the achievement tracker being pushed down to accomodate the Engineer build UI
+    // Default: 3 (stored)
+    hud_achievement_count_engineer                                  3
 
-    // Open initial menu screen and load the background bsp,
-    // but only if no other level is being loaded, and we're not in developer mode
-    startupmenu
+    ////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Default valve.rc contents
+    ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    // Not used anymore, according to mastercoms
-    // (previously was used long ago to use the CPU to scan for small decals to stop rendering)
-    // Default: 5
-    r_decal_cullsize                                                1
+// load the base configuration
+//exec default.cfg
+r_decal_cullsize 1
 
-    // Allow menu backgrounds to display randomly by unlocking all chapters
+// Setup custom controller
+exec joystick.cfg
+
+// run a user script file if present
+exec autoexec.cfg
+
+//
+// stuff command line statements
+//
+stuffcmds
+
+// display the startup level
+startupmenu
+
+sv_unlockedchapters 99
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////
+    // HUD commands to run AFTER user configurations.
+    // This way, we enforce users to such values.
+    // "stored" means the values are saved in config.cfg, so you don't need to
+    // reset such ConVars if you uninstall budhud. If not specified, it is not stored, so a
+    // game restart is sufficient to automatically reset such ones.
+    ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    // Setting this to 0 can cause stuttering issues with Engineer PDAs (maybe Spy disguise as well?)
     // Default: 1
-    sv_unlockedchapters                                             99
+    vgui_cache_res_files                                            1
+
+    // The hud is designed to work around minmode being set to 0, but it will work either way
+    // Default: 0 (stored)
+    cl_hud_minmode                                                  0
+
+    // Shows robots left in mvm all-time
+    // Default: 0 (stored)
+    cl_mvm_wave_status_visible_during_wave                          1
+
+    // Spectating TargetID location
+    // Default: 0 (stored)
+    tf_spectator_target_location                                    0
+
+    // Filter out error messages about animation customizations it cant find
+    // Default: 0
+    con_filter_enable                                               1
+    // Default: ""
+    con_filter_text_out                                             "Couldn't find script file"
+
+    // Enforce consistent Target ID alpha to possible fix lag for some users
+    // Does not actually change anything, but the game's code can be weird in regard to this
+    // Default: 100 (stored)
+    tf_hud_target_id_alpha                                          255
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Commands recommended by mastercoms
+    ////////////////////////////////////////////////////////////////////////////////////////////////////
+    // This is the interpolation value for the Payload HUD updates
+    // Default: 0.2
+    hud_escort_interp                                               0.1
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////
+    // HUD start-up echo
+    ////////////////////////////////////////////////////////////////////////////////////////////////////
 
     echo ;
     echo ;
@@ -37,36 +96,3 @@
     echo ======================================================;
     echo ;
     echo ;
-
-    // Setting this to 0 can cause stuttering issues with Engineer PDAs (maybe spy disguise as well?)
-    // Default: 1
-    vgui_cache_res_files                                            1
-
-    // The hud is designed to work around minmode being set to 0, but it will work either way
-    // Default: 0
-    cl_hud_minmode                                                  0
-
-    // Shows robots left in mvm all-time
-    // Default: 0
-    cl_mvm_wave_status_visible_during_wave                          1
-
-    // Any more would cause overlap due to the achievement tracker being pushed down to accomodate the engineer build UI
-    // Default: 3
-    hud_achievement_count_engineer                                  3
-
-    // Spectating TargetID location
-    // Default: 0
-    tf_spectator_target_location                                    0
-
-    // Filter out error messages about animation customizations it cant find
-    // Default: 0
-    con_filter_enable                                               1
-    // Default: ""
-    con_filter_text_out                                             "Couldn't find script file"
-
-    ////////////////////////////////////////////////////////////////////////////////////////////////////
-    // Commands recommended by mastercoms
-    ////////////////////////////////////////////////////////////////////////////////////////////////////
-    // This is the interp for the payload HUD updates
-    // Default: 0.2
-    hud_escort_interp                                               0.1


### PR DESCRIPTION
Redux version of https://github.com/rbjaxter/budhud/pull/620.

`bh_aliases.cfg`: adjust comment to match actual used value.

`bh_captions*` : added `cc_captiontrace 0` in order to avoid possible console spam for missing captions. For Captions OFF CFG file, added more default commands with default values.

`bh_stream*`: Added `voice_enable` too, misc. comment changes, changed `cl_hud_killstreak_display_time` to default game value in ON CFG.

---------------

Main changes are in valve.rc as follows:

1. `hud_achievement_count_engineer 3` is now run before everything to ensure user configurations can override it. More specifically, this can be set by mastercomfig via autoexec with the HUD Achievement module.
2. Added `tf_hud_target_id_alpha 255`. This is used by FlawHUD, and IIRC it was related to fix either a performance problem or merely just for visual consistentecy. I am not sure, but this should be fine in budhud too.
3. File structure is a bit different now, but achieves the same result. Look at its comments to better understand it. Default valve.rc content has been pasted without any special comments.

HUD echo remains unchanged; just moved it to the bottom.