### PR TITLE
Update DefaultVerySmall in chat scheme

### DIFF
--- a/_budhud/resource/chatscheme.res
+++ b/_budhud/resource/chatscheme.res
@@ -77,11 +77,14 @@
 
         "DefaultVerySmall"	// Courtesy of qkeitoe (GH issue #557). Missing in default file, causes language indicator to not appear if missing
         {
+            "isproportional"                                        "only"
+
             "1"
             {
                 "name"                                              "Lato Semibold" [!$POSIX]
                 "name"                                              "Verdana" [$POSIX]
-                "tall"                                              "12"
+                "tall"                                              "12" [!$POSIX]
+                "tall"                                              "14" [$POSIX]
                 "weight"                                            "0"
                 "range"                                             "0x0020 0x1EFF"
                 "yres"                                              "480 599"
@@ -91,7 +94,8 @@
             {
                 "name"                                              "Lato Semibold" [!$POSIX]
                 "name"                                              "Verdana" [$POSIX]
-                "tall"                                              "12"
+                "tall"                                              "13" [!$POSIX]
+                "tall"                                              "16" [$POSIX]
                 "weight"                                            "0"
                 "range"                                             "0x0020 0x1EFF"
                 "yres"                                              "600 767"
@@ -101,7 +105,8 @@
             {
                 "name"                                              "Lato Semibold" [!$POSIX]
                 "name"                                              "Verdana" [$POSIX]
-                "tall"                                              "12"
+                "tall"                                              "14" [!$POSIX]
+                "tall"                                              "16" [$POSIX]
                 "weight"                                            "0"
                 "range"                                             "0x0020 0x1EFF"
                 "yres"                                              "768 1023"
@@ -112,7 +117,8 @@
             {
                 "name"                                              "Lato Semibold" [!$POSIX]
                 "name"                                              "Verdana" [$POSIX]
-                "tall"                                              "14"
+                "tall"                                              "16" [!$POSIX]
+                "tall"                                              "18" [$POSIX]
                 "weight"                                            "0"
                 "range"                                             "0x0020 0x1EFF"
                 "yres"                                              "1024 1199"


### PR DESCRIPTION
It seems the DefaultVerySmall is basically a one-to-one copy of the Default entry from

https://raw.githubusercontent.com/rbjaxter/budhud/refs/heads/master/_tf2hud/resource/chatscheme.res

so update the DefaultVerySmall to match TALL values for POSIX and non-POSIX differences.

Also adds the "isproportional" missing entry.

I cannot actually attest if this makes any difference, I have not noticed any (language indicator does not work for me).