### PR TITLE
Increase font size of item meter labels

### DIFF
--- a/_budhud/resource/ui/huditemeffectmeter_base_meters.res
+++ b/_budhud/resource/ui/huditemeffectmeter_base_meters.res
@@ -63,7 +63,7 @@
         "proportionaltoparent"                                      "1"
         "labelText"                                                 "#TF_Ball"
         "textAlignment"                                             "center"
-        "font"                                                      "bh_Font6"
+        "font"                                                      "bh_Font8"
         "enabled"                                                   "0"
         "disabledfgcolor2_override"                                 "bh_metertext"
     }


### PR DESCRIPTION
In my opinion, the current legibility of item meter labels (the text inside them) is a bit bad. We could do something similar to FlawHUD I think, but that would break HUD style:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/768f6d33-fcdc-43a4-a7b9-fd6c77be506b" />

Ideally, we could do something similar to the old FlawHUD style, which is simply by replacing the text font with a bold variant:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e75909f5-f050-430f-89e6-1965ea0844af" />

(i.e. Lato Bold, if that exists)

Although, for now, I've just increased the size a bit. It helps with the issue, although it does not fix it. Tested on Linux.

I am not sure if there is some font definition in budhud that would achieve a similar effect to the old FlawHUD style. If so, that would be more desirable, even with or without this PR.

I have to admit that increasing the font size does look a bit wrong as if it impedes the text from being "centered" correctly or something.

# Font size 6 (current)

<img width="1920" height="1080" alt="image-4" src="https://github.com/user-attachments/assets/243f794f-b181-4f94-a325-f22c48488dd8" />

# Font size 8 (new):

<img width="1920" height="1080" alt="image-3" src="https://github.com/user-attachments/assets/bbce9b9d-a9e5-4aa9-99c6-d8727ee087ab" />
