### PR TITLE
Remove damage number outline for Linux clients

### DIFF
--- a/_budhud/resource/ui/huddamageaccount.res
+++ b/_budhud/resource/ui/huddamageaccount.res
@@ -5,8 +5,10 @@
         "PositiveColor"                                             "bh_HealColor"
     //  "NegativeColor"                                             ""
         "EventColor"                                                "bh_UberDrop"
-        "delta_item_font"                                           "bh_Font20Outline"
-        "delta_item_font_big"                                       "bh_Font20Outline"
+        "delta_item_font"                                           "bh_Font20Outline" [!$LINUX] // FIXME: Remove those $LINUX overrides once TF2 Linux has correct font rendering for outlines
+        "delta_item_font"                                           "bh_Font20" [$LINUX]
+        "delta_item_font_big"                                       "bh_Font20Outline" [!$LINUX]
+        "delta_item_font_big"                                       "bh_Font20" [$LINUX]
     }
 
     "DamageAccountValue"


### PR DESCRIPTION
Due to the multitude of issues that apply to fonts on Linux (see https://github.com/SolarLightTF2/solarlighthud-redux/issues/10#issuecomment-4565572652), especially in regards to outlines and (drop) shadows, the font used for damage numbers always looks a bit off because they are not properly rendered, in comparison with its Windows counterpart. It is the same font, but something in the Linux port makes it render bad. This is especially noticeable if you zoom-in more closely, and is noticeable during gameplay where you always feel something is wrong, even by a tiny bit.

This is also the reason as to why custom crosshairs with outlines or shadows do not work as good on Linux as they do on Windows, since font shadow/outline being rendered incorrectly (since custom crosshairs are a font hack into the HUD) makes them look bad.

This PR makes it so the damage numbers do not have any shadows or outlines, but only on Linux. Looks better to the eyes, since you stop noticing the jankiness of font outlines being rendered incorrectly. A FIXME comment is also added, in order to remove it in the future.

This is nothing to do with budhud itself, but rather due to how fonts are rendered.

Other parts of the HUD do not have such perceptible jankiness, since the HUD outlines/shadows render correctly in such parts. This is one of the most jarring ones, in my opinion.

Coincidentally, the default HUD is not affect, because damage numbers in the default HUD do not have any outlines or shadows.

# Default combat text (with outline) on Linux. Zoom-in to notice the jarriness.

<img width="1920" height="1080" alt="image-8" src="https://github.com/user-attachments/assets/73b3da69-674f-4629-987f-76f188eccba8" />

<img width="1920" height="1080" alt="image-9" src="https://github.com/user-attachments/assets/d78f00f5-fd37-4be5-b14b-bc1dbcab2a0e" />

<img width="1920" height="1080" alt="image-10" src="https://github.com/user-attachments/assets/5fa18377-4555-4ca4-aae8-6a3987b7ae98" />

# Drop shadow variant (a test, but it got even worse, IMO)
<img width="1920" height="1080" alt="image-11" src="https://github.com/user-attachments/assets/147540d6-2e9a-4226-bcbd-17b75ccbd8bf" />

# Variant without outline or shadow (this PR)

<img width="1920" height="1080" alt="image-5" src="https://github.com/user-attachments/assets/df95c89e-acea-4945-9194-53ff0f310d35" />
